### PR TITLE
Bump the guide-dependencies-gradle group across 2 directories with 1 …

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.3.0'
+	id 'org.springframework.boot' version '3.4.2'
 	id 'java'
 }
 

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.3.0'
+	id 'org.springframework.boot' version '3.4.2'
 	id 'java'
 }
 


### PR DESCRIPTION
…update

Bumps the guide-dependencies-gradle group with 1 update in the /complete directory: [org.springframework.boot](https://github.com/spring-projects/spring-boot).
Bumps the guide-dependencies-gradle group with 1 update in the /initial directory: [org.springframework.boot](https://github.com/spring-projects/spring-boot).


Updates `org.springframework.boot` from 3.3.0 to 3.4.2
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v3.3.0...v3.4.2)

Updates `org.springframework.boot` from 3.3.0 to 3.4.2
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v3.3.0...v3.4.2)

---
updated-dependencies:
- dependency-name: org.springframework.boot dependency-type: direct:production update-type: version-update:semver-minor dependency-group: guide-dependencies-gradle
- dependency-name: org.springframework.boot dependency-type: direct:production update-type: version-update:semver-minor dependency-group: guide-dependencies-gradle ...