### PR TITLE
Bump the guide-dependencies-maven group across 2 directories with 1 u…

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.4.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.4.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
…pdate

Bumps the guide-dependencies-maven group with 1 update in the /complete directory: [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot).
Bumps the guide-dependencies-maven group with 1 update in the /initial directory: [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot).


Updates `org.springframework.boot:spring-boot-starter-parent` from 3.3.0 to 3.4.2
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v3.3.0...v3.4.2)

Updates `org.springframework.boot:spring-boot-starter-parent` from 3.3.0 to 3.4.2
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v3.3.0...v3.4.2)

---
updated-dependencies:
- dependency-name: org.springframework.boot:spring-boot-starter-parent dependency-type: direct:production update-type: version-update:semver-minor dependency-group: guide-dependencies-maven
- dependency-name: org.springframework.boot:spring-boot-starter-parent dependency-type: direct:production update-type: version-update:semver-minor dependency-group: guide-dependencies-maven ...